### PR TITLE
build script using npm executables of angular

### DIFF
--- a/procweb-webui/build.sh
+++ b/procweb-webui/build.sh
@@ -2,5 +2,5 @@
 
 export NG_CLI_ANALYTICS=false
 npm i
-ng analytics off
-ng build --output-hashing none
+npx ng analytics off
+npx ng build --output-hashing none


### PR DESCRIPTION
ng is not installed locally, but comes via `npm i`

I suggest to call it via `npx` 